### PR TITLE
Add w3c support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,39 +2,43 @@
 
 This repository demonstrates how to run Appium Python tests on BrowserStack App Automate.
 
+## Based on
+
+These code samples are currently based on:
+
+- **Appium-Python-Client:** `2.6.1`
+- **Protocol:** `W3C`
+
 ## Setup
 
 ### Requirements
 
-1. Python 3.6+ or Python 2.7+
-    
-    - For Windows, download latest python version from [here](https://www.python.org/downloads/windows/) and run the installer executable
-    - For Mac and Linux, run `python --version` to see what python version is pre-installed. If you want a different version download from [here](https://www.python.org/downloads/)
+1. Python 3.7+
+
+   > **_NOTE:_** Since v1.0.0, only Python 3.7+ is supported.
+
+   - For Windows, download latest python version from [here](https://www.python.org/downloads/windows/) and run the installer executable
+   - For Mac and Linux, run `python --version` to see what python version is pre-installed. If you want a different version download from [here](https://www.python.org/downloads/)
 
 2. Package Manager pip
 
-    Note : `pip` comes installed with Python 2.7.9+ and python 3.4+
+   Note : `pip` comes installed with python 3.4+
 
-    - If `pip` is not installed, follow these instructions:
-        - Securely download get-pip.py by following this link: [get-pip.py](https://bootstrap.pypa.io/get-pip.py) or use following cURL command to download it:
+   - If `pip` is not installed, follow these instructions:
 
-        ```sh
-        curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-        ```
+     - Securely download get-pip.py by following this link: [get-pip.py](https://bootstrap.pypa.io/get-pip.py) or use following cURL command to download it:
 
-        - After dowloading, run the file :
+     ```sh
+     curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+     ```
 
-            - For Python 3
+     - After dowloading, run the file :
 
-                ```sh
-                python3 get-pip.py
-                ```
+       - For Python 3
 
-            - For Python 2
-
-                ```sh
-                python2 get-pip.py
-                ```
+         ```sh
+         python3 get-pip.py
+         ```
 
 ### Install the dependencies
 
@@ -42,15 +46,9 @@ To install the dependencies, run the following command in project's base directo
 
 - For Python 3
 
-    ```sh
-    pip3 install -r requirements.txt
-    ```
-
-- For Python 2
-
-    ```sh
-    pip2 install -r requirements.txt
-    ```
+  ```sh
+  pip3 install -r requirements.txt
+  ```
 
 ## Getting Started
 
@@ -71,7 +69,6 @@ curl -u "YOUR_USERNAME:YOUR_ACCESS_KEY" \
 Ensure that @ symbol is prepended to the file path in the above request. Please note the `app_url` value returned in the API response. We will use this to set the application under test while configuring the test later on.
 
 **Note**: If you do not have an .apk or .ipa file and are looking to simply try App Automate, you can download and test using our [sample Android app](https://www.browserstack.com/app-automate/sample-apps/android/WikipediaSample.apk) or [sample iOS app](https://www.browserstack.com/app-automate/sample-apps/ios/BStackSampleApp.ipa).
-
 
 **2. Configure and run your first test**
 
@@ -107,7 +104,6 @@ Ensure that @ symbol is prepended to the file path in the above request. Please 
 
 **Note**: If you do not have an .apk or .ipa file and are looking to simply try App Automate, you can download and test using our [sample Android Local app](https://www.browserstack.com/app-automate/sample-apps/android/LocalSample.apk) or [sample iOS Local app](https://www.browserstack.com/app-automate/sample-apps/ios/LocalSample.ipa).
 
-
 **2. Configure and run your local test**
 
 Open `browserstack_sample_local` file in `Android` or `iOS` folder :
@@ -118,7 +114,7 @@ Open `browserstack_sample_local` file in `Android` or `iOS` folder :
 
 - Set the device and OS version
 
-- Ensure that `browserstack.local` capability is set to `true`. Within the test script, there is code snippet that automatically establishes Local Testing connection to BrowserStack servers using Python binding for BrowserStack Local. 
+- Ensure that `browserstack.local` capability is set to `true`. Within the test script, there is code snippet that automatically establishes Local Testing connection to BrowserStack servers using Python binding for BrowserStack Local.
 
 - If you have uploaded your own app update the test case
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Open `browserstack_sample_local` file in `Android` or `iOS` folder :
 
 - Set the device and OS version
 
-- Ensure that `browserstack.local` capability is set to `true`. Within the test script, there is code snippet that automatically establishes Local Testing connection to BrowserStack servers using Python binding for BrowserStack Local.
+- Ensure that `local` capability is set to `true`. Within the test script, there is code snippet that automatically establishes Local Testing connection to BrowserStack servers using Python binding for BrowserStack Local.
 
 - If you have uploaded your own app update the test case
 

--- a/android/browserstack_sample.py
+++ b/android/browserstack_sample.py
@@ -1,6 +1,6 @@
 from appium import webdriver
 from appium.options.android import UiAutomator2Options
-from appium.webdriver.common.mobileby import MobileBy
+from appium.webdriver.common.appiumby import AppiumBy
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 import time
@@ -15,13 +15,13 @@ options = UiAutomator2Options().load_capabilities({
     "deviceName" : "Google Pixel 3",
 
     # Set URL of the application under test
-    "app" : "<bs://app-id>",
+    "app" : "bs://<app-id>",
 
     # Set other BrowserStack capabilities
     'bstack:options' : {
         "projectName" : "First Python project",
         "buildName" : "browserstack-build-1",
-        "sessionName" : "first_test",
+        "sessionName" : "BStack first_test",
 
         # Set your access credentials
         "userName" : "YOUR_USERNAME",
@@ -30,22 +30,22 @@ options = UiAutomator2Options().load_capabilities({
 })
 
 # Initialize the remote Webdriver using BrowserStack remote URL
-# and desired capabilities defined above
+# and options defined above
 driver = webdriver.Remote("http://hub-cloud.browserstack.com/wd/hub", options=options)
 
 # Test case for the BrowserStack sample Android app.
 # If you have uploaded your app, update the test case here.
 search_element = WebDriverWait(driver, 30).until(
-    EC.element_to_be_clickable((MobileBy.ACCESSIBILITY_ID, "Search Wikipedia"))
+    EC.element_to_be_clickable((AppiumBy.ACCESSIBILITY_ID, "Search Wikipedia"))
 )
 search_element.click()
 search_input = WebDriverWait(driver, 30).until(
     EC.element_to_be_clickable(
-        (MobileBy.ID, "org.wikipedia.alpha:id/search_src_text"))
+        (AppiumBy.ID, "org.wikipedia.alpha:id/search_src_text"))
 )
 search_input.send_keys("BrowserStack")
 time.sleep(5)
-search_results = driver.find_elements_by_class_name("android.widget.TextView")
+search_results = driver.find_elements(AppiumBy.CLASS_NAME, "android.widget.TextView")
 assert (len(search_results) > 0)
 
 # Invoke driver.quit() after the test is done to indicate that the test is completed.

--- a/android/browserstack_sample.py
+++ b/android/browserstack_sample.py
@@ -31,7 +31,7 @@ options = UiAutomator2Options().load_capabilities({
 
 # Initialize the remote Webdriver using BrowserStack remote URL
 # and options defined above
-driver = webdriver.Remote("http://hub-cloud.browserstack.com/wd/hub", options=options)
+driver = webdriver.Remote("http://hub.browserstack.com/wd/hub", options=options)
 
 # Test case for the BrowserStack sample Android app.
 # If you have uploaded your app, update the test case here.

--- a/android/browserstack_sample.py
+++ b/android/browserstack_sample.py
@@ -5,43 +5,45 @@ from selenium.webdriver.support import expected_conditions as EC
 import time
 
 desired_cap = {
-    # Set your access credentials
-    "browserstack.user" : "YOUR_USERNAME",
-    "browserstack.key" : "YOUR_ACCESS_KEY",
-
     # Set URL of the application under test
     "app" : "bs://<app-id>",
 
     # Specify device and os_version for testing
-    "device" : "Google Pixel 3",
-    "os_version" : "9.0",
-    
+    "deviceName": "Google Pixel 3",
+    "platformName": "android",
+    "platformVersion": "9.0",
+
     # Set other BrowserStack capabilities
-    "project" : "First Python project", 
-    "build" : "browserstack-build-1",
-    "name" : "first_test"
+    "bstack:options": {
+        "userName" : "YOUR_USERNAME",
+        "accessKey" : "YOUR_ACCESS_KEY",
+        "projectName" : "First Python project",
+        "buildName" : "browserstack-build-1",
+        "sessionName" : "first_test"
+    }
 }
 
 # Initialize the remote Webdriver using BrowserStack remote URL
 # and desired capabilities defined above
 driver = webdriver.Remote(
-    command_executor="http://hub-cloud.browserstack.com/wd/hub", 
+    command_executor="http://hub-cloud.browserstack.com/wd/hub",
     desired_capabilities=desired_cap
 )
 
-# Test case for the BrowserStack sample Android app. 
-# If you have uploaded your app, update the test case here. 
+# Test case for the BrowserStack sample Android app.
+# If you have uploaded your app, update the test case here.
 search_element = WebDriverWait(driver, 30).until(
     EC.element_to_be_clickable((MobileBy.ACCESSIBILITY_ID, "Search Wikipedia"))
 )
 search_element.click()
 search_input = WebDriverWait(driver, 30).until(
-    EC.element_to_be_clickable((MobileBy.ID, "org.wikipedia.alpha:id/search_src_text"))
+    EC.element_to_be_clickable(
+        (MobileBy.ID, "org.wikipedia.alpha:id/search_src_text"))
 )
 search_input.send_keys("BrowserStack")
 time.sleep(5)
 search_results = driver.find_elements_by_class_name("android.widget.TextView")
-assert(len(search_results) > 0)
+assert (len(search_results) > 0)
 
 # Invoke driver.quit() after the test is done to indicate that the test is completed.
 driver.quit()

--- a/android/browserstack_sample.py
+++ b/android/browserstack_sample.py
@@ -1,33 +1,37 @@
 from appium import webdriver
+from appium.options.android import UiAutomator2Options
 from appium.webdriver.common.mobileby import MobileBy
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 import time
 
-desired_cap = {
-    # Set your access credentials
-    "browserstack.user" : "YOUR_USERNAME",
-    "browserstack.key" : "YOUR_ACCESS_KEY",
+# Options are only available since client version 2.3.0
+# If you use an older client then switch to desired_capabilities
+# instead: https://github.com/appium/python-client/pull/720
+options = UiAutomator2Options().load_capabilities({
+    # Specify device and os_version for testing
+    "platformName" : "android",
+    "platformVersion" : "9.0",
+    "deviceName" : "Google Pixel 3",
 
     # Set URL of the application under test
-    "app" : "bs://<app-id>",
+    "app" : "<bs://app-id>",
 
-    # Specify device and os_version for testing
-    "device" : "Google Pixel 3",
-    "os_version" : "9.0",
-    
     # Set other BrowserStack capabilities
-    "project" : "First Python project", 
-    "build" : "browserstack-build-1",
-    "name" : "first_test"
-}
+    'bstack:options' : {
+        "projectName" : "First Python project",
+        "buildName" : "browserstack-build-1",
+        "sessionName" : "first_test",
+
+        # Set your access credentials
+        "userName" : "YOUR_USERNAME",
+        "accessKey" : "YOUR_ACCESS_KEY"
+    }
+})
 
 # Initialize the remote Webdriver using BrowserStack remote URL
 # and desired capabilities defined above
-driver = webdriver.Remote(
-    command_executor="http://hub-cloud.browserstack.com/wd/hub", 
-    desired_capabilities=desired_cap
-)
+driver = webdriver.Remote("http://hub-cloud.browserstack.com/wd/hub", options=options)
 
 # Test case for the BrowserStack sample Android app. 
 # If you have uploaded your app, update the test case here. 

--- a/android/browserstack_sample_local.py
+++ b/android/browserstack_sample_local.py
@@ -1,5 +1,6 @@
 from appium import webdriver
-from appium.webdriver.common.mobileby import MobileBy
+from appium.options.android import UiAutomator2Options
+from appium.webdriver.common.appiumby import AppiumBy
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from browserstack.local import Local
@@ -9,7 +10,10 @@ import time
 userName = "YOUR_USERNAME"
 accessKey = "YOUR_ACCESS_KEY"
 
-desired_caps = {
+# Options are only available since client version 2.3.0
+# If you use an older client then switch to desired_capabilities
+# instead: https://github.com/appium/python-client/pull/720
+options = UiAutomator2Options().load_capabilities({
     # Set URL of the application under test
     "app" : "bs://<app-id>",
 
@@ -19,20 +23,15 @@ desired_caps = {
     "platformVersion": "9.0",
 
     # Set other BrowserStack capabilities
-    "project" : "First Python Local project", 
-    "build" : "browserstack-build-1",
-    "name" : "local_test",
-
-    # Set other BrowserStack capabilities
     "bstack:options": {
         "userName" : userName,
         "accessKey" : accessKey,
         "projectName" : "First Python Local project",
         "buildName" : "browserstack-build-1",
-        "sessionName" : "local_test",
-        "local" : True
+        "sessionName" : "BStack local_test",
+        "local" : "true"
     }
-}
+})
 
 bs_local = None
 
@@ -50,23 +49,20 @@ def stop_local():
 start_local()
 
 # Initialize the remote Webdriver using BrowserStack remote URL
-# and desired capabilities defined above
-driver = webdriver.Remote(
-    command_executor="http://hub-cloud.browserstack.com/wd/hub", 
-    desired_capabilities=desired_caps
-)
+# and options defined above
+driver = webdriver.Remote("http://hub-cloud.browserstack.com/wd/hub", options=options)
 
 # Test case for the BrowserStack sample Android app. 
 # If you have uploaded your app, update the test case here. 
 test_button = WebDriverWait(driver, 30).until(
-    EC.element_to_be_clickable((MobileBy.ID, "com.example.android.basicnetworking:id/test_action"))
+    EC.element_to_be_clickable((AppiumBy.ID, "com.example.android.basicnetworking:id/test_action"))
 )
 test_button.click()
 WebDriverWait(driver, 30).until(
-    EC.element_to_be_clickable((MobileBy.CLASS_NAME, "android.widget.TextView"))
+    EC.element_to_be_clickable((AppiumBy.CLASS_NAME, "android.widget.TextView"))
 )
 test_element = None
-search_results = driver.find_elements_by_class_name("android.widget.TextView")
+search_results = driver.find_elements(AppiumBy.CLASS_NAME,"android.widget.TextView")
 for result in search_results:
     if result.text.__contains__("The active connection is"):
         test_element = result

--- a/android/browserstack_sample_local.py
+++ b/android/browserstack_sample_local.py
@@ -50,7 +50,7 @@ start_local()
 
 # Initialize the remote Webdriver using BrowserStack remote URL
 # and options defined above
-driver = webdriver.Remote("http://hub-cloud.browserstack.com/wd/hub", options=options)
+driver = webdriver.Remote("http://hub.browserstack.com/wd/hub", options=options)
 
 # Test case for the BrowserStack sample Android app. 
 # If you have uploaded your app, update the test case here. 

--- a/android/browserstack_sample_local.py
+++ b/android/browserstack_sample_local.py
@@ -10,23 +10,28 @@ userName = "YOUR_USERNAME"
 accessKey = "YOUR_ACCESS_KEY"
 
 desired_caps = {
-    "browserstack.user" : userName,
-    "browserstack.key" : accessKey,
-
     # Set URL of the application under test
-    "app" : "<bs://app-id>",
+    "app" : "bs://<app-id>",
 
     # Specify device and os_version for testing
-    "device" : "Google Pixel 3",
-    "os_version" : "9.0",
-
-    #Set BrowserStack Local capability as True
-    "browserstack.local": True,
+    "deviceName": "Google Pixel 3",
+    "platformName": "android",
+    "platformVersion": "9.0",
 
     # Set other BrowserStack capabilities
     "project" : "First Python Local project", 
     "build" : "browserstack-build-1",
-    "name" : "local_test"
+    "name" : "local_test",
+
+    # Set other BrowserStack capabilities
+    "bstack:options": {
+        "userName" : userName,
+        "accessKey" : accessKey,
+        "projectName" : "First Python Local project",
+        "buildName" : "browserstack-build-1",
+        "sessionName" : "local_test",
+        "local" : True
+    }
 }
 
 bs_local = None

--- a/ios/browserstack_sample.py
+++ b/ios/browserstack_sample.py
@@ -1,10 +1,14 @@
 from appium import webdriver
-from appium.webdriver.common.mobileby import MobileBy
+from appium.options.ios import XCUITestOptions
+from appium.webdriver.common.appiumby import AppiumBy
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 import time
 
-desired_cap = {
+# Options are only available since client version 2.3.0
+# If you use an older client then switch to desired_capabilities
+# instead: https://github.com/appium/python-client/pull/720
+options = XCUITestOptions().load_capabilities({
     # Set URL of the application under test
     "app" : "bs://<app-id>",
 
@@ -19,30 +23,27 @@ desired_cap = {
         "accessKey" : "YOUR_ACCESS_KEY",
         "projectName" : "First Python project",
         "buildName" : "browserstack-build-1",
-        "sessionName" : "first_test"
+        "sessionName" : "BStack first_test"
     }
-}
+})
 
 # Initialize the remote Webdriver using BrowserStack remote URL
-# and desired capabilities defined above
-driver = webdriver.Remote(
-    command_executor="http://hub-cloud.browserstack.com/wd/hub", 
-    desired_capabilities=desired_cap
-)
+# and options defined above
+driver = webdriver.Remote("http://hub-cloud.browserstack.com/wd/hub", options=options)
 
-# Test case for the BrowserStack sample Android app. 
+# Test case for the BrowserStack sample iOS app.
 # If you have uploaded your app, update the test case here. 
 text_button = WebDriverWait(driver, 30).until(
-    EC.element_to_be_clickable((MobileBy.ACCESSIBILITY_ID, "Text Button"))
+    EC.element_to_be_clickable((AppiumBy.ACCESSIBILITY_ID, "Text Button"))
 )
 text_button.click()
 text_input = WebDriverWait(driver, 30).until(
-    EC.element_to_be_clickable((MobileBy.ACCESSIBILITY_ID, "Text Input"))
+    EC.element_to_be_clickable((AppiumBy.ACCESSIBILITY_ID, "Text Input"))
 )
 text_input.send_keys("hello@browserstack.com"+"\n")
 time.sleep(5)
 text_output = WebDriverWait(driver, 30).until(
-    EC.element_to_be_clickable((MobileBy.ACCESSIBILITY_ID, "Text Output"))
+    EC.element_to_be_clickable((AppiumBy.ACCESSIBILITY_ID, "Text Output"))
 )
 if text_output!=None and text_output.text=="hello@browserstack.com":
 	assert True

--- a/ios/browserstack_sample.py
+++ b/ios/browserstack_sample.py
@@ -5,21 +5,22 @@ from selenium.webdriver.support import expected_conditions as EC
 import time
 
 desired_cap = {
-    # Set your access credentials
-    "browserstack.user" : "YOUR_USERNAME",
-    "browserstack.key" : "YOUR_ACCESS_KEY",
-
     # Set URL of the application under test
     "app" : "bs://<app-id>",
 
     # Specify device and os_version for testing
-    "device" : "iPhone 11 Pro",
-    "os_version" : "13",
-    
+    "deviceName": "iPhone 11 Pro",
+    "platformName": "ios",
+    "platformVersion": "13",
+
     # Set other BrowserStack capabilities
-    "project" : "First Python project", 
-    "build" : "browserstack-build-1",
-    "name" : "first_test"
+    "bstack:options": {
+        "userName" : "YOUR_USERNAME",
+        "accessKey" : "YOUR_ACCESS_KEY",
+        "projectName" : "First Python project",
+        "buildName" : "browserstack-build-1",
+        "sessionName" : "first_test"
+    }
 }
 
 # Initialize the remote Webdriver using BrowserStack remote URL

--- a/ios/browserstack_sample.py
+++ b/ios/browserstack_sample.py
@@ -29,7 +29,7 @@ options = XCUITestOptions().load_capabilities({
 
 # Initialize the remote Webdriver using BrowserStack remote URL
 # and options defined above
-driver = webdriver.Remote("http://hub-cloud.browserstack.com/wd/hub", options=options)
+driver = webdriver.Remote("http://hub.browserstack.com/wd/hub", options=options)
 
 # Test case for the BrowserStack sample iOS app.
 # If you have uploaded your app, update the test case here. 

--- a/ios/browserstack_sample_local.py
+++ b/ios/browserstack_sample_local.py
@@ -1,5 +1,6 @@
 from appium import webdriver
-from appium.webdriver.common.mobileby import MobileBy
+from appium.options.ios import XCUITestOptions
+from appium.webdriver.common.appiumby import AppiumBy
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from browserstack.local import Local
@@ -9,19 +10,17 @@ import os
 userName = "YOUR_USERNAME"
 accessKey = "YOUR_ACCESS_KEY"
 
-desired_caps = {
+# Options are only available since client version 2.3.0
+# If you use an older client then switch to desired_capabilities
+# instead: https://github.com/appium/python-client/pull/720
+options = XCUITestOptions().load_capabilities({
     # Set URL of the application under test
     "app" : "bs://<app-id>",
 
     # Specify device and os_version for testing
-    "deviceName": "iPhone 11 Pro",
+    "deviceName": "iPhone XS",
     "platformName": "ios",
-    "platformVersion": "13",
-
-    # Set other BrowserStack capabilities
-    "project" : "First Python Local project", 
-    "build" : "browserstack-build-1",
-    "name" : "local_test",
+    "platformVersion": "12",
 
     # Set other BrowserStack capabilities
     "bstack:options": {
@@ -29,10 +28,10 @@ desired_caps = {
         "accessKey" : accessKey,
         "projectName" : "First Python Local project",
         "buildName" : "browserstack-build-1",
-        "sessionName" : "local_test",
-        "local" : True
+        "sessionName" : "BStack first_test",
+        "local" : "true"
     }
-}
+})
 
 bs_local = None
 
@@ -47,27 +46,24 @@ def stop_local():
     bs_local.stop()
 
 def existence_lambda(s):
-    result = s.find_element_by_accessibility_id("ResultBrowserStackLocal").get_attribute("value")
+    result = s.find_element(AppiumBy.ACCESSIBILITY_ID, "ResultBrowserStackLocal").get_attribute("value")
     return result and len(result) > 0
 
 # Start BrowserStack local binary
 start_local()
 
 # Initialize the remote Webdriver using BrowserStack remote URL
-# and desired capabilities defined above
-driver = webdriver.Remote(
-    command_executor="http://hub-cloud.browserstack.com/wd/hub", 
-    desired_capabilities=desired_caps
-)
+# and options defined above
+driver = webdriver.Remote("http://hub-cloud.browserstack.com/wd/hub", options=options)
 
 # Test case for the BrowserStack sample iOS app. 
 # If you have uploaded your app, update the test case here. 
 test_button = WebDriverWait(driver, 30).until(
-    EC.element_to_be_clickable((MobileBy.ACCESSIBILITY_ID, "TestBrowserStackLocal"))
+    EC.element_to_be_clickable((AppiumBy.ACCESSIBILITY_ID, "TestBrowserStackLocal"))
 )
 test_button.click()
 WebDriverWait(driver, 30).until(existence_lambda)
-result_element = driver.find_element_by_accessibility_id("ResultBrowserStackLocal")
+result_element = driver.find_element(AppiumBy.ACCESSIBILITY_ID, "ResultBrowserStackLocal")
 result_string = result_element.text.lower()
 if result_string.__contains__("not working"):
     screenshot_file = "%s/screenshot.png" % os.getcwd()

--- a/ios/browserstack_sample_local.py
+++ b/ios/browserstack_sample_local.py
@@ -28,7 +28,7 @@ options = XCUITestOptions().load_capabilities({
         "accessKey" : accessKey,
         "projectName" : "First Python Local project",
         "buildName" : "browserstack-build-1",
-        "sessionName" : "BStack first_test",
+        "sessionName" : "BStack local_test",
         "local" : "true"
     }
 })
@@ -54,7 +54,7 @@ start_local()
 
 # Initialize the remote Webdriver using BrowserStack remote URL
 # and options defined above
-driver = webdriver.Remote("http://hub-cloud.browserstack.com/wd/hub", options=options)
+driver = webdriver.Remote("http://hub.browserstack.com/wd/hub", options=options)
 
 # Test case for the BrowserStack sample iOS app. 
 # If you have uploaded your app, update the test case here. 

--- a/ios/browserstack_sample_local.py
+++ b/ios/browserstack_sample_local.py
@@ -10,23 +10,28 @@ userName = "YOUR_USERNAME"
 accessKey = "YOUR_ACCESS_KEY"
 
 desired_caps = {
-    "browserstack.user" : userName,
-    "browserstack.key" : accessKey,
-
     # Set URL of the application under test
-    "app" : "<bs://app-id>",
+    "app" : "bs://<app-id>",
 
     # Specify device and os_version for testing
-    "device" : "iPhone 11 Pro",
-    "os_version" : "13",
+    "deviceName": "iPhone 11 Pro",
+    "platformName": "ios",
+    "platformVersion": "13",
 
-    #Set BrowserStack Local capability as True
-    "browserstack.local": True,
-
-     # Set other BrowserStack capabilities
+    # Set other BrowserStack capabilities
     "project" : "First Python Local project", 
     "build" : "browserstack-build-1",
-    "name" : "local_test"
+    "name" : "local_test",
+
+    # Set other BrowserStack capabilities
+    "bstack:options": {
+        "userName" : userName,
+        "accessKey" : accessKey,
+        "projectName" : "First Python Local project",
+        "buildName" : "browserstack-build-1",
+        "sessionName" : "local_test",
+        "local" : True
+    }
 }
 
 bs_local = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-Appium-Python-Client==0.52;python_version < '3.0'
-Appium-Python-Client==1.0.2;python_version >= '3.0'
+Appium-Python-Client==2.6.1;python_version >= '3.0'
 browserstack-local==1.2.2


### PR DESCRIPTION
JIRA: [Update python appium sample repo to support w3c protocol](https://browserstack.atlassian.net/browse/ASI-4230)

This PR:
- Replace desired_cap with equivalent options class (upgrade appium client) 
- Drop support for python 2 (since no appium client supported) 
- add note in README to call out it's w3c sample & Appium client version
- Use AppiumBy instead of deprecated MobileBy