### PR TITLE
SDK-5741: Migrate browserstack-sdk install from PyPI to S3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-browserstack-sdk
+browserstack-sdk @ https://sdk-assets.browserstack.com/python/browserstack_sdk-latest.tar.gz
 Appium-Python-Client==2.6.1;python_version >= '3.0'


### PR DESCRIPTION
## Summary
- Update `requirements.txt` to install `browserstack-sdk` from BrowserStack-hosted S3 instead of PyPI
- PyPI flagged the package for obfuscated code; the package is now hosted at `sdk-assets.browserstack.com`
- Install URL: `https://sdk-assets.browserstack.com/python/browserstack_sdk-latest.tar.gz`

## Test plan
- [ ] Run `pip install -r requirements.txt` in a clean venv — SDK installs from S3
- [ ] Run tests with `browserstack-sdk` CLI — tests pass, observability build generates

🤖 Generated with [Claude Code](https://claude.com/claude-code)